### PR TITLE
Fix microtype

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -17,7 +17,7 @@
 #'
 #'
 #' @param thai_font (Character) Global Thai font to set for this package, must be a valid font in your machine.
-#'
+#' @param line_spacing (Numeric) Global spacing between each line. Line spacing 1.5 is recommended for Thai language (default).
 #' @return Display message to R console and return list of configurations (invisibly)
 #' @export
 #'
@@ -28,12 +28,12 @@
 #' # View Settings
 #' thaipdf_config_get()
 #' }
-thaipdf_config_set <- function(thai_font = "TH Sarabun New"){
+thaipdf_config_set <- function(thai_font = "TH Sarabun New", line_spacing = 1.5){
 
   # Validate Metadata
-  thaipdf_config_validate(thai_font = thai_font)
+  thaipdf_config_validate(thai_font = thai_font, line_spacing = line_spacing)
   # Metadata: Named List as Pandoc Var
-  metadata <- list(thai_font = thai_font)
+  metadata <- list(thai_font = thai_font, line_spacing = line_spacing)
 
   # All relevant file paths in PKG
   paths <- thaipdf_paths()
@@ -47,7 +47,7 @@ thaipdf_config_set <- function(thai_font = "TH Sarabun New"){
   )
 
   # Write config.yml
-  suppressWarnings(yaml::write_yaml(metadata, file = paths[["path_config"]]))
+  yaml::write_yaml(metadata, file = paths[["path_config"]])
 
   # Render to all output: thai-preamble.tex
   for (i in seq_along(paths_out)) {
@@ -62,6 +62,7 @@ thaipdf_config_set <- function(thai_font = "TH Sarabun New"){
   thaipdf_config_get()
 
 }
+
 
 
 # Get Config --------------------------------------------------------------
@@ -88,13 +89,23 @@ thaipdf_config_get <- function(){
 #' Validate thaipdf_config Input
 #'
 #' @param thai_font
+#' @param line_spacing
 #'
 #' @return display error if invalid
 #' @noRd
-thaipdf_config_validate <- function(thai_font = "TH Sarabun New"){
+thaipdf_config_validate <- function(thai_font = "TH Sarabun New",
+                                    line_spacing = 1.5
+){
 
-  is_valid <- all(is.character(thai_font), length(thai_font) == 1, (thai_font != ""))
-  if(!is_valid) stop("`thai_font` is invalid. You must provide only 1 valid Thai font name.", call. = FALSE)
+  # Validate Thai font
+  is_valid_font <- all(is.character(thai_font), length(thai_font) == 1, (thai_font != ""))
+  if(!is_valid_font) stop("`thai_font` is invalid. You must provide only 1 valid Thai font name.", call. = FALSE)
+
+  # Validate Line Spacing
+  is_valid_lin_sp <- all(is.numeric(line_spacing), length(line_spacing) == 1, line_spacing > 0)
+  if(!is_valid_lin_sp) stop("`line_spacing` is invalid. You must provide a numeric value.", call. = FALSE)
+
+
 
 }
 
@@ -105,8 +116,11 @@ thaipdf_config_validate <- function(thai_font = "TH Sarabun New"){
 print.thaipdf_config <- function(x, ...){
 
   th_font <- x[["thai_font"]]
+  line_spacing <- x[["line_spacing"]]
+
   cli::cli_h2("thaipdf Global Setting")
   cli::cli_li("Thai font setting is {.val {th_font}}")
+  cli::cli_li("Line spacing is {.val {line_spacing}}")
   invisible(x)
-
 }
+

--- a/R/use_thai_preamble.R
+++ b/R/use_thai_preamble.R
@@ -115,10 +115,9 @@ ui_inform_yaml <- function(in_header = "path-to-preamble.tex") {
 
   cli::cli_rule(left = "Like This")
 
-
   message("    latex_engine: xelatex
     includes:
-      in_header:", "foo.tex")
+      in_header: ", in_header)
   message("\n")
 
   cli::cli_rule()

--- a/R/use_thai_preamble.R
+++ b/R/use_thai_preamble.R
@@ -23,6 +23,7 @@
 #'
 #' @param name (Character) Thai \LaTeX preamble file name or path of file to create, relative to current working directory. Defaults is `thai-preamble.tex`
 #' @param thai_font (Character) Name of the Thai font to use, i.e., "TH Sarabun New" (default), "Laksaman".
+#' @param line_spacing (Numeric) Spacing between each line. Line spacing 1.5 is recommended for Thai language (default).
 #' @param open (Logical) Open the newly created file for editing? Using default editor of `.tex` to open.
 #' @param overwrite (Logical) If file already exist, do you want to overwrite?
 #'
@@ -40,6 +41,7 @@
 #' }
 use_thai_preamble <- function(name = "thai-preamble.tex",
                               thai_font = "TH Sarabun New",
+                              line_spacing = 1.5,
                               open = FALSE,
                               overwrite = FALSE
 ){
@@ -56,9 +58,9 @@ use_thai_preamble <- function(name = "thai-preamble.tex",
   }
 
   # Validate Metadata
-  thaipdf_config_validate(thai_font = thai_font)
+  thaipdf_config_validate(thai_font = thai_font, line_spacing = line_spacing)
   # Metadata: Named List as Pandoc Var
-  metadata <- list(thai_font = thai_font)
+  metadata <- list(thai_font = thai_font, line_spacing = line_spacing)
 
   # All relevant file paths in PKG
   paths <- thaipdf_paths()
@@ -75,6 +77,7 @@ use_thai_preamble <- function(name = "thai-preamble.tex",
   # Info to Console
   cli::cli_alert_success("Writing {.val {out_name}} at {.file {write_path}}")
   cli::cli_alert_success("Thai font was set to {.val {thai_font}} in the preamble.")
+  cli::cli_alert_success("Line spacing was set to {.val {line_spacing}} in the preamble.")
 
   # Inform what TODO
   ui_inform_yaml(name_clean)
@@ -131,5 +134,6 @@ ui_inform_yaml <- function(in_header = "path-to-preamble.tex") {
   cli::cli_li("LaTeX setting in Thai {.url http://pioneer.netserv.chula.ac.th/~wdittaya/LaTeX/LaTeXThai.pdf}")
 
 }
+
 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -64,7 +64,7 @@ knitr::kable(
 
 การสร้าง PDF จาก R Markdown นั้น จะผ่านกระบวนการที่แปลงเอกสารหลายขั้นตอน ซึ่ง **ภาษาไทย** จะมีปัญหาที่ขั้นตอน
 
-> **LaTeX -> PDF**
+> **LaTeX -\> PDF**
 
 วิธีแก้นั้น จะต้องมีการตั้งค่าต่างๆ ใน LaTeX preamble และ YAML header ของ R Markdown เพื่อให้รองรับกับการใช้งานภาษาไทยได้ โดย R package นี้จึงถูกสร้างขึ้นเพื่อ**ช่วยให้ง่ายขึ้น**ใน workflow จุดนี้
 
@@ -152,7 +152,11 @@ output:
 
 -   **`thaipdf::thaipdf_config_get()`** ไว้เรียกดูการตั้งค่า global setting และ
 
--   **`thaipdf::thaipdf_config_set()`** ไว้ตั้งค่า global setting ซึ่งในขณะนี้มี option เดียวคือ การตั้งค่าชนิดฟอนท์ภาษาไทยที่ต้องการ (default font จะเป็น "TH Sarabun New") โดยใช้ argument `thai_font`
+-   **`thaipdf::thaipdf_config_set()`** ไว้ตั้งค่า global setting ซึ่งในขณะนี้มี option คือ argument
+
+    -   `thai_font`: ตั้งค่าชนิดฟอนท์ภาษาไทยที่ต้องการ (default font จะเป็น "TH Sarabun New")
+
+    -   `line_spacing`: ตั้งค่าระยะห่างระหว่างบรรทัด ตัวอักษรภาษาไทยแนะนำให้ห่าง บรรทัดครึ่ง default จึงเป็น `1.5`
 
 ```{r load-thaipdf}
 library(thaipdf)
@@ -220,7 +224,7 @@ output:
 
 ฟังก์ชั่น **`thaipdf::use_thai_preamble()`** ถูกออกแบบในทำนอง [usethis package](https://usethis.r-lib.org) โดยจะทำการ
 
--   **สร้างไฟล์ LaTeX preamble** ชื่อว่า `thai-preamble.tex` (default) โดยจะมีการเรียกใช้ LaTeX package และคำสั่งต่างๆ ในการตั้งค่าภาษาไทยในไฟล์นี้ การตั้งค่า font ภาษาไทยหลักจะเป็น "TH Sarabun New" แต่สามารถเปลี่ยนได้ที่ argument `thai_font`
+-   **สร้างไฟล์ LaTeX preamble** ชื่อว่า `thai-preamble.tex` (default) โดยจะมีการเรียกใช้ LaTeX package และคำสั่งต่างๆ ในการตั้งค่าภาษาไทยในไฟล์นี้ เช่น ฟอนท์ภาษาไทย (`thai_font`) หรือ ระยะห่างระหว่างบรรทัด (`line_spacing`)
 
 จากนั้นให้ **ปรับ [YAML header](https://bookdown.org/yihui/rmarkdown-cookbook/rmarkdown-anatomy.html)** ของ R Markdown ในส่วนของ [`pdf_document:`](https://pkgs.rstudio.com/rmarkdown/reference/pdf_document.html) หรือ [`bookdown::pdf_document2:`](https://pkgs.rstudio.com/bookdown/reference/html_document2.html) ซึ่งต้องทำเอง ดังนี้
 
@@ -265,7 +269,7 @@ unlink("thai-preamble.tex")
 
 # Todo
 
--   [ ] Write unit test
+-   [x] Write unit test
 
 -   [ ] PKG down site
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](h
 การสร้าง PDF จาก R Markdown นั้น จะผ่านกระบวนการที่แปลงเอกสารหลายขั้นตอน
 ซึ่ง **ภาษาไทย** จะมีปัญหาที่ขั้นตอน
 
-> **LaTeX -> PDF**
+> **LaTeX -\> PDF**
 
 วิธีแก้นั้น จะต้องมีการตั้งค่าต่างๆ ใน LaTeX preamble และ YAML header
 ของ R Markdown เพื่อให้รองรับกับการใช้งานภาษาไทยได้ โดย R package
@@ -154,7 +154,7 @@ output field ของ YAML header ที่ 2 function หลังนี้ย
 ``` yaml
 title: "R Markdown ภาษาไทย"
 author: "`thaipdf` package"
-date: "16/02/2022"
+date: "04/03/2022"
 fontsize: 10pt
 output: 
   thaipdf::thaipdf_document:
@@ -174,8 +174,13 @@ output:
     setting และ
 
 -   **`thaipdf::thaipdf_config_set()`** ไว้ตั้งค่า global setting
-    ซึ่งในขณะนี้มี option เดียวคือ การตั้งค่าชนิดฟอนท์ภาษาไทยที่ต้องการ
-    (default font จะเป็น “TH Sarabun New”) โดยใช้ argument `thai_font`
+    ซึ่งในขณะนี้มี option คือ argument
+
+    -   `thai_font`: ตั้งค่าชนิดฟอนท์ภาษาไทยที่ต้องการ (default font
+        จะเป็น “TH Sarabun New”)
+
+    -   `line_spacing`: ตั้งค่าระยะห่างระหว่างบรรทัด
+        ตัวอักษรภาษาไทยแนะนำให้ห่าง บรรทัดครึ่ง default จึงเป็น `1.5`
 
 ``` r
 library(thaipdf)
@@ -190,6 +195,7 @@ thaipdf_config_get()
 #> ── thaipdf Global Setting ──
 #> 
 #> • Thai font setting is "TH Sarabun New"
+#> • Line spacing is 1.5
 ```
 
 เปลี่ยน font เป็น “Laksaman”
@@ -202,6 +208,7 @@ thaipdf_config_set(thai_font = "Laksaman")
 #> ── thaipdf Global Setting ──
 #> 
 #> • Thai font setting is "Laksaman"
+#> • Line spacing is 1.5
 ```
 
 ------------------------------------------------------------------------
@@ -262,8 +269,8 @@ package](https://usethis.r-lib.org) โดยจะทำการ
 
 -   **สร้างไฟล์ LaTeX preamble** ชื่อว่า `thai-preamble.tex` (default)
     โดยจะมีการเรียกใช้ LaTeX package และคำสั่งต่างๆ
-    ในการตั้งค่าภาษาไทยในไฟล์นี้ การตั้งค่า font ภาษาไทยหลักจะเป็น “TH
-    Sarabun New” แต่สามารถเปลี่ยนได้ที่ argument `thai_font`
+    ในการตั้งค่าภาษาไทยในไฟล์นี้ เช่น ฟอนท์ภาษาไทย (`thai_font`) หรือ
+    ระยะห่างระหว่างบรรทัด (`line_spacing`)
 
 จากนั้นให้ **ปรับ [YAML
 header](https://bookdown.org/yihui/rmarkdown-cookbook/rmarkdown-anatomy.html)**
@@ -286,6 +293,7 @@ header](https://bookdown.org/yihui/rmarkdown-cookbook/rmarkdown-anatomy.html)**
 thaipdf::use_thai_preamble()
 #> ✓ Writing "thai-preamble.tex" at '/Users/kittipos/my_pkg/thaipdf/thai-preamble.tex'
 #> ✓ Thai font was set to "TH Sarabun New" in the preamble.
+#> ✓ Line spacing was set to 1.5 in the preamble.
 #> 
 #> ── TODO ────────────────────────────────────────────────────────────────────────
 #> For YAML header of R Markdown in `pdf_document:` or `bookdown::pdf_document2:`
@@ -296,20 +304,15 @@ thaipdf::use_thai_preamble()
 #>     latex_engine: xelatex
 #>     includes:
 #>       in_header: thai-preamble.tex
+#> 
 #> ────────────────────────────────────────────────────────────────────────────────
-#> 
-#> 
 #> 
 #> • Add LaTeX macro `\sloppy` to the beginning of the body of R Markdown (just
 #> after YAML header).
 #> 
-#> 
-#> 
 #> For more details see
-#> 
 #> • How to include preamble in R Markdown
 #> <https://bookdown.org/yihui/rmarkdown-cookbook/latex-preamble.html>
-#> 
 #> • LaTeX setting in Thai
 #> <http://pioneer.netserv.chula.ac.th/~wdittaya/LaTeX/LaTeXThai.pdf>
 ```
@@ -343,10 +346,10 @@ output:
 
 # Todo
 
--   [ ] Write unit test
+-   [x] Write unit test
 
 -   [ ] PKG down site
 
 ------------------------------------------------------------------------
 
-Last Updated: 2022-02-16
+Last Updated: 2022-03-04

--- a/dev/config.Rmd
+++ b/dev/config.Rmd
@@ -23,6 +23,17 @@ usethis::use_test("config")
 fs::path_package("thaipdf") 
 ```
 
+### Config Parameters
+
+`thai_font`: thai language font
+`line_spacing`: line spacing (default = 1.5)
+
+TO ADD
+
+`par_indent`: paragraph indent (default = `NULL`)
+`par_spacing`: paragraph spacing (default = `NULL`)
+
+
 
 ## Setting Config
 
@@ -33,12 +44,12 @@ render USER-based `thai-preamble` in `rmarkdown/` and `preTeX/` folder from temp
 args: `thai_font`
 
 ```{r thaipdf_config_set}
-thaipdf_config_set <- function(thai_font = "TH Sarabun New"){
+thaipdf_config_set <- function(thai_font = "TH Sarabun New", line_spacing = 1.5){
   
   # Validate Metadata
-  thaipdf_config_validate(thai_font = thai_font)
+  thaipdf_config_validate(thai_font = thai_font, line_spacing = line_spacing)
   # Metadata: Named List as Pandoc Var
-  metadata <- list(thai_font = thai_font)
+  metadata <- list(thai_font = thai_font, line_spacing = line_spacing)
     
   # All relevant file paths in PKG
   paths <- thaipdf_paths()
@@ -74,15 +85,25 @@ thaipdf_config_set()
 ### Validate Metadata
 
 ```{r thaipdf_config_validate}
-thaipdf_config_validate <- function(thai_font = "TH Sarabun New"){
+thaipdf_config_validate <- function(thai_font = "TH Sarabun New", 
+                                    line_spacing = 1.5
+                                    ){
     
-  is_valid <- all(is.character(thai_font), length(thai_font) == 1, (thai_font != ""))
-  if(!is_valid) stop("`thai_font` is invalid. You must provide only 1 valid Thai font name.", call. = FALSE)
+  # Validate Thai font
+  is_valid_font <- all(is.character(thai_font), length(thai_font) == 1, (thai_font != ""))
+  if(!is_valid_font) stop("`thai_font` is invalid. You must provide only 1 valid Thai font name.", call. = FALSE)
+  
+  # Validate Line Spacing
+  is_valid_lin_sp <- all(is.numeric(line_spacing), length(line_spacing) == 1, line_spacing > 0)
+  if(!is_valid_lin_sp) stop("`line_spacing` is invalid. You must provide a numeric value.", call. = FALSE)
+  
+  
   
 }
 
 thaipdf_config_validate()
 thaipdf_config_validate(1)
+thaipdf_config_validate(line_spacing = "a")
 ```
 #### Tes: Validation
 
@@ -155,6 +176,7 @@ print.thaipdf_config <- function(x, ...){
   th_font <- x[["thai_font"]]
   cli::cli_h2("thaipdf Global Setting")
   cli::cli_li("Thai font setting is {.val {th_font}}")
+  cli::cli_li("Line spacing is {.val {line_spacing}}")
   invisible(x)
 }
 

--- a/dev/plan.Rmd
+++ b/dev/plan.Rmd
@@ -10,6 +10,8 @@ here::i_am("my_dev/plan.Rmd")
 library(here)
 ```
 
+
+
 Nomenclatures: DEV (for developer), USER (for user)
 
 ## Package Structure
@@ -34,6 +36,15 @@ Nomenclatures: DEV (for developer), USER (for user)
 
         -   thai-preamble.tex
         -   before_body.tex
+
+
+### Config Params
+
+When update config param, I must Update
+
+- `config.yml`, `template-thai-preamble.tex`
+- `thaipdf_config_set()`, `thaipdf_config_validate()`, `print.thaipdf_config()`
+
 
 ### Create Structures
 
@@ -69,7 +80,7 @@ thai-pdf-rmd/
 ```{r}
 usethis::use_rmarkdown_template(
   template_name = "Thai PDF R Markdown",
-  template_dir = "thai-pdf-rmd"
+  template_dir = "thai-pdf-rmd",
   template_description = "R Markdown PDF stand-alone template that supports Thai language.",
   template_create_dir = FALSE
 )

--- a/dev/pre-temp.Rmd
+++ b/dev/pre-temp.Rmd
@@ -47,6 +47,7 @@ User may **overide global setting** by input metadata to  `rmarkdown::pandoc_tem
 ```{r use_thai_preamble}
 use_thai_preamble <- function(name = "thai-preamble.tex",
                               thai_font = "TH Sarabun New",
+                              line_spacing = 1.5,
                               open = FALSE,
                               overwrite = FALSE
                               ){
@@ -63,9 +64,9 @@ use_thai_preamble <- function(name = "thai-preamble.tex",
     }
   
   # Validate Metadata
-  thaipdf_config_validate(thai_font = thai_font)
+  thaipdf_config_validate(thai_font = thai_font, line_spacing = line_spacing)
   # Metadata: Named List as Pandoc Var
-  metadata <- list(thai_font = thai_font)
+  metadata <- list(thai_font = thai_font, line_spacing = line_spacing)
   
   # All relevant file paths in PKG
   paths <- thaipdf_paths()
@@ -82,6 +83,7 @@ use_thai_preamble <- function(name = "thai-preamble.tex",
   # Info to Console
   cli::cli_alert_success("Writing {.val {out_name}} at {.file {write_path}}")
   cli::cli_alert_success("Thai font was set to {.val {thai_font}} in the preamble.")
+  cli::cli_alert_success("Line spacing was set to {.val {line_spacing}} in the preamble.")
   
   # Inform what TODO
   ui_inform_yaml(name_clean)
@@ -144,13 +146,9 @@ ui_inform_yaml <- function(in_header = "path-to-preamble.tex") {
 
   cli::cli_rule(left = "Like This")
 
-  # cat("    latex_engine: xelatex
-  #   includes:
-  #     in_header:", in_header)
-  # cat("\n")
   message("    latex_engine: xelatex
     includes:
-      in_header:", "foo.tex")
+      in_header: ", in_header)
   message("\n")
 
   cli::cli_rule()

--- a/inst/preTeX/thai-preamble.tex
+++ b/inst/preTeX/thai-preamble.tex
@@ -28,8 +28,8 @@ Sarabun New}
 \setTransitionTo{Thai}{\begin{thailang}} % Use environment "thailang" when found Thai font.
 \setTransitionFrom{Thai}{\end{thailang}} % If not found, end the environment.
 
-%% ---- Paragraph Spacing ---- %%
-\renewcommand{\baselinestretch}{1.5} % Line Spacing (1.5 recommended for Thai language)
+%% ---- Spacing ---- %%
+\renewcommand{\baselinestretch}{1.5} % Line Spacing (1.5 is recommended for Thai language)
 
 
 %% ---- using alphabatic language ---- %%

--- a/inst/preTeX/thai-preamble.tex
+++ b/inst/preTeX/thai-preamble.tex
@@ -21,19 +21,16 @@
 
 % ตั้งฟอนต์หลักภาษาไทย ที่น่าใช้ เช่น: "TH Sarabun New", "Laksaman"
 \newfontfamily{\thaifont}[Scale=MatchUppercase,Mapping=textext]{TH
-Sarabun New} 
+Sarabun New}
 \newenvironment{thailang}{\thaifont}{} % create environment for Thai language
 \usepackage[Latin,Thai]{ucharclasses} % ตั้งค่าให้ใช้ "thailang" environment เฉพาะ string ที่เป็น Unicode ภาษาไทย
 
 \setTransitionTo{Thai}{\begin{thailang}} % Use environment "thailang" when found Thai font.
 \setTransitionFrom{Thai}{\end{thailang}} % If not found, end the environment.
 
-%% ---- spacing between lines ---- %%
-\usepackage{setspace}
-% \singlespacing % เป็น default setting 
+%% ---- Paragraph Spacing ---- %%
+\renewcommand{\baselinestretch}{1.5} % Line Spacing (1.5 recommended for Thai language)
 
-% ใช้ one-half spacing สำหรับภาษาไทย เพราะ singlespacing นั้นแคบไปสําหรับข้อความภาษาไทยซึ่งมีอักขระบนล่างมาก
-\onehalfspacing 
 
 %% ---- using alphabatic language ---- %%
 \usepackage{polyglossia}
@@ -52,7 +49,7 @@ Sarabun New}
 % \usepackage{xcolor}
 % \hypersetup{
 %     colorlinks, % for colorful link
-%     linkcolor={red!50!black}, 
+%     linkcolor={red!50!black},
 %     citecolor={blue!50!black},
 %     urlcolor={blue!80!black}
 %     }

--- a/inst/rmarkdown/templates/thai-pdf-rmd-w-pre/skeleton/preTeX/thai-preamble.tex
+++ b/inst/rmarkdown/templates/thai-pdf-rmd-w-pre/skeleton/preTeX/thai-preamble.tex
@@ -28,8 +28,8 @@ Sarabun New}
 \setTransitionTo{Thai}{\begin{thailang}} % Use environment "thailang" when found Thai font.
 \setTransitionFrom{Thai}{\end{thailang}} % If not found, end the environment.
 
-%% ---- Paragraph Spacing ---- %%
-\renewcommand{\baselinestretch}{1.5} % Line Spacing (1.5 recommended for Thai language)
+%% ---- Spacing ---- %%
+\renewcommand{\baselinestretch}{1.5} % Line Spacing (1.5 is recommended for Thai language)
 
 
 %% ---- using alphabatic language ---- %%

--- a/inst/rmarkdown/templates/thai-pdf-rmd-w-pre/skeleton/preTeX/thai-preamble.tex
+++ b/inst/rmarkdown/templates/thai-pdf-rmd-w-pre/skeleton/preTeX/thai-preamble.tex
@@ -21,19 +21,16 @@
 
 % ตั้งฟอนต์หลักภาษาไทย ที่น่าใช้ เช่น: "TH Sarabun New", "Laksaman"
 \newfontfamily{\thaifont}[Scale=MatchUppercase,Mapping=textext]{TH
-Sarabun New} 
+Sarabun New}
 \newenvironment{thailang}{\thaifont}{} % create environment for Thai language
 \usepackage[Latin,Thai]{ucharclasses} % ตั้งค่าให้ใช้ "thailang" environment เฉพาะ string ที่เป็น Unicode ภาษาไทย
 
 \setTransitionTo{Thai}{\begin{thailang}} % Use environment "thailang" when found Thai font.
 \setTransitionFrom{Thai}{\end{thailang}} % If not found, end the environment.
 
-%% ---- spacing between lines ---- %%
-\usepackage{setspace}
-% \singlespacing % เป็น default setting 
+%% ---- Paragraph Spacing ---- %%
+\renewcommand{\baselinestretch}{1.5} % Line Spacing (1.5 recommended for Thai language)
 
-% ใช้ one-half spacing สำหรับภาษาไทย เพราะ singlespacing นั้นแคบไปสําหรับข้อความภาษาไทยซึ่งมีอักขระบนล่างมาก
-\onehalfspacing 
 
 %% ---- using alphabatic language ---- %%
 \usepackage{polyglossia}
@@ -52,7 +49,7 @@ Sarabun New}
 % \usepackage{xcolor}
 % \hypersetup{
 %     colorlinks, % for colorful link
-%     linkcolor={red!50!black}, 
+%     linkcolor={red!50!black},
 %     citecolor={blue!50!black},
 %     urlcolor={blue!80!black}
 %     }

--- a/inst/templates/config.yml
+++ b/inst/templates/config.yml
@@ -1,1 +1,2 @@
 thai_font: TH Sarabun New
+line_spacing: 1.5

--- a/inst/templates/template-thai-preamble.tex
+++ b/inst/templates/template-thai-preamble.tex
@@ -20,19 +20,16 @@
 % \setmonofont{TeX Gyre Cursor} % Free Courier
 
 % ตั้งฟอนต์หลักภาษาไทย ที่น่าใช้ เช่น: "TH Sarabun New", "Laksaman"
-\newfontfamily{\thaifont}[Scale=MatchUppercase,Mapping=textext]{$thai_font$} 
+\newfontfamily{\thaifont}[Scale=MatchUppercase,Mapping=textext]{$thai_font$}
 \newenvironment{thailang}{\thaifont}{} % create environment for Thai language
 \usepackage[Latin,Thai]{ucharclasses} % ตั้งค่าให้ใช้ "thailang" environment เฉพาะ string ที่เป็น Unicode ภาษาไทย
 
 \setTransitionTo{Thai}{\begin{thailang}} % Use environment "thailang" when found Thai font.
 \setTransitionFrom{Thai}{\end{thailang}} % If not found, end the environment.
 
-%% ---- spacing between lines ---- %%
-\usepackage{setspace}
-% \singlespacing % เป็น default setting 
+%% ---- Paragraph Spacing ---- %%
+\renewcommand{\baselinestretch}{1.5} % Line Spacing (1.5 recommended for Thai language)
 
-% ใช้ one-half spacing สำหรับภาษาไทย เพราะ singlespacing นั้นแคบไปสําหรับข้อความภาษาไทยซึ่งมีอักขระบนล่างมาก
-\onehalfspacing 
 
 %% ---- using alphabatic language ---- %%
 \usepackage{polyglossia}
@@ -51,7 +48,7 @@
 % \usepackage{xcolor}
 % \hypersetup{
 %     colorlinks, % for colorful link
-%     linkcolor={red!50!black}, 
+%     linkcolor={red!50!black},
 %     citecolor={blue!50!black},
 %     urlcolor={blue!80!black}
 %     }

--- a/inst/templates/template-thai-preamble.tex
+++ b/inst/templates/template-thai-preamble.tex
@@ -27,8 +27,8 @@
 \setTransitionTo{Thai}{\begin{thailang}} % Use environment "thailang" when found Thai font.
 \setTransitionFrom{Thai}{\end{thailang}} % If not found, end the environment.
 
-%% ---- Paragraph Spacing ---- %%
-\renewcommand{\baselinestretch}{1.5} % Line Spacing (1.5 recommended for Thai language)
+%% ---- Spacing ---- %%
+\renewcommand{\baselinestretch}{$line_spacing$} % Line Spacing (1.5 is recommended for Thai language)
 
 
 %% ---- using alphabatic language ---- %%

--- a/man/thaipdf_config_set.Rd
+++ b/man/thaipdf_config_set.Rd
@@ -5,12 +5,14 @@
 \alias{thaipdf_config_get}
 \title{Set or Get Global thaipdf Configuration}
 \usage{
-thaipdf_config_set(thai_font = "TH Sarabun New")
+thaipdf_config_set(thai_font = "TH Sarabun New", line_spacing = 1.5)
 
 thaipdf_config_get()
 }
 \arguments{
 \item{thai_font}{(Character) Global Thai font to set for this package, must be a valid font in your machine.}
+
+\item{line_spacing}{(Numeric) Global spacing between each line. Line spacing 1.5 is recommended for Thai language (default).}
 }
 \value{
 Display message to R console and return list of configurations (invisibly)

--- a/man/use_thai_preamble.Rd
+++ b/man/use_thai_preamble.Rd
@@ -7,6 +7,7 @@
 use_thai_preamble(
   name = "thai-preamble.tex",
   thai_font = "TH Sarabun New",
+  line_spacing = 1.5,
   open = FALSE,
   overwrite = FALSE
 )
@@ -15,6 +16,8 @@ use_thai_preamble(
 \item{name}{(Character) Thai \LaTeX preamble file name or path of file to create, relative to current working directory. Defaults is \code{thai-preamble.tex}}
 
 \item{thai_font}{(Character) Name of the Thai font to use, i.e., "TH Sarabun New" (default), "Laksaman".}
+
+\item{line_spacing}{(Numeric) Spacing between each line. Line spacing 1.5 is recommended for Thai language (default).}
 
 \item{open}{(Logical) Open the newly created file for editing? Using default editor of \code{.tex} to open.}
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -4,20 +4,28 @@
 
 test_that("thaipdf_config_set() works", {
 
+  # Set New
   new_font <- "Sarabun"
-  new_config_ls <- thaipdf_config_set(thai_font = new_font)
+  line_spacing <- 2
 
-  expect_equal(new_config_ls[["thai_font"]], new_font)
+  new_config_ls <- thaipdf_config_set(thai_font = new_font, line_spacing = line_spacing)
 
+  expect_equal(new_config_ls[["thai_font"]], new_font) # Check font
+  expect_equal(new_config_ls[["line_spacing"]], line_spacing) # Check Spacing
+
+  # Reset
   default_config_ls <- thaipdf_config_set()
 
   expect_equal(default_config_ls[["thai_font"]], "TH Sarabun New")
+  expect_equal(default_config_ls[["line_spacing"]], 1.5)
 
 })
 
 # Config: Get -------------------------------------------------------------
 
 test_that("thaipdf_config_get() works",{
+
+
   config_ls <- thaipdf_config_get()
   # return list
   expect_type(config_ls, "list")
@@ -32,8 +40,12 @@ test_that("thaipdf_config_get() works",{
 
 test_that("thaipdf_config_validate() works", {
 
+  # Thai font
   expect_error(thaipdf_config_validate(thai_font = 1))
   expect_error(thaipdf_config_validate(thai_font = c("")))
   expect_error(thaipdf_config_validate(thai_font = c("a", "b")))
+
+  expect_error(thaipdf_config_validate(line_spacing = "a"))
+  expect_error(thaipdf_config_validate(line_spacing = 1:2))
 
 })


### PR DESCRIPTION
# Fix warning from PKG microtype 

From this issue: #1

## Update

- add parameter `line_spacing` to config.yml, template-thai-preamble.tex
- add argument `line_spacing = 1.5` to `thaipdf_config_set()`, `thaipdf_config_validate()`, `print.thaipdf_config()`

## Details


**Problem in this line**

```latex
%% ---- spacing between lines ---- %%
\usepackage{setspace}
% \singlespacing % เป็น default setting

% ใช้ one-half spacing สำหรับภาษาไทย เพราะ singlespacing นั้นแคบไปสําหรับข้อความภาษาไทยซึ่งมีอักขระบนล่างมาก
\onehalfspacing
```


**Solution: Change to this**

```latex
%% ---- Paragraph Spacing ---- %%
\renewcommand{\baselinestretch}{1.5} % Line Spacing (recommended for Thai language)

```