### PR TITLE
CRAN Fix thaipdf 0.1.1

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^cran-comments\.md$
 ^doc$
 ^Meta$
+^CRAN-RELEASE$

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2022-04-15.
+Once it is accepted, delete this file and tag the release (commit a20045d).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: thaipdf
 Title: R Markdown to PDF in Thai Language
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(
     person("Kittipos", "Sirivongrungson", role = c("aut", "cre"), email = "ki11ip0.s.a.s@gmail.com"),
     person("Dittaya", "Wanvarie", role = c("cph"), email = "dittaya.w@chula.ac.th", comment = "Author of an article on Thai language typesetting in LaTeX")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# thaipdf 0.1.2
+
+-   Fix function documentation and examples.
+
 # thaipdf 0.1.1
 
 -   Rename R Markdown template folder from `preTeX` to `pre-tex` for recommended practice of all lower-case letter in sub-directory.

--- a/R/thaipdf.R
+++ b/R/thaipdf.R
@@ -18,15 +18,14 @@
 #' for `includes` and `latex_engine`.
 #'
 #'
-#' @return R Markdown output format passing to [`rmarkdown::render()`]
-#' @export
+#' @return An S3 object of class "rmarkdown_output_format" to pass to [`rmarkdown::render()`]
 #'
 #' @seealso
 #' * How to use [`rmarkdown::pdf_document`], please see [official documentation](https://bookdown.org/yihui/rmarkdown/pdf-document.html#other-features).
 #' * How to use [thaipdf_book()].
 #' @examples
-#' if(FALSE){
-#'  library(rmarkdown)
+#' \dontrun{
+#' library(rmarkdown)
 #'
 #'  # Simple Conversion
 #'  render("input.Rmd", output_format = thaipdf::thaipdf_document())
@@ -39,6 +38,7 @@
 #'           pandoc_args = pandoc_metadata_arg("fontsize", "10pt")
 #'         ))
 #' }
+#' @export
 thaipdf_document <- function(thai_font = "TH Sarabun New",
                              line_spacing = 1.5,
                              ...
@@ -52,8 +52,6 @@ thaipdf_document <- function(thai_font = "TH Sarabun New",
                                       line_spacing = line_spacing)
 
   # Pandoc conversion will fail If I remove temp file when exit
-  ## See: https://stackoverflow.com/questions/28300713/how-and-when-should-i-use-on-exit
-  # on.exit({unlink(tmp_preamble)}, add = TRUE)
   rmarkdown::pdf_document(
     latex_engine = "xelatex",
     includes = rmarkdown::includes(
@@ -74,13 +72,14 @@ thaipdf_document <- function(thai_font = "TH Sarabun New",
 #' It is a wrapper around [`bookdown::pdf_book()`](https://pkgs.rstudio.com/bookdown/reference/pdf_book.html) with argument `base_format` set to [thaipdf_document()].
 #'
 #' @param ... Arguments passed to [`pdf_book()`](https://pkgs.rstudio.com/bookdown/reference/pdf_book.html), and then to [thaipdf_document()]. You may supply argument `thai_font` and `line_spacing` in here.
+#'
+#' @return An S3 object of class "rmarkdown_output_format" to pass to [`rmarkdown::render()`]
 #' @seealso
 #' * How to use [`bookdown::pdf_book()`], please see [official documentation](https://bookdown.org/yihui/bookdown/latexpdf.html)
 #' * How to use [thaipdf_document()].
 #'
-#' @export
 #' @examples
-#' if(FALSE){
+#' \dontrun{
 #'  library(rmarkdown)
 #'
 #'  # Simple Conversion
@@ -93,6 +92,7 @@ thaipdf_document <- function(thai_font = "TH Sarabun New",
 #'           pandoc_args = pandoc_metadata_arg("fontsize", "10pt")
 #'         ))
 #' }
+#' @export
 thaipdf_book <- function(...) {
 
   # Check bookdown

--- a/R/thaipdf.R
+++ b/R/thaipdf.R
@@ -12,7 +12,7 @@
 #' This function injects preamble fragment of Thai \LaTeX typesetting into the preamble of output \LaTeX via [`includes`](https://pkgs.rstudio.com/rmarkdown/reference/includes.html) argument,
 #' and set `latex_engine` to "xelatex".
 #'
-#' @param thai_font (Character) Name of the Thai font to use. Default font is "TH Sarabun New". It can be any Thai font that your system have.
+#' @param thai_font (Character) Name of the Thai font to use. Default font is "TH Sarabun New". It can be any Thai font that installed in your system.
 #' @param line_spacing (Numeric) Spacing between each line. Line spacing 1.5 is recommended for Thai language (default).
 #' @param ... Arguments to pass to [`pdf_document()`](https://pkgs.rstudio.com/rmarkdown/reference/pdf_document.html). You may supply any valid arguments of [`pdf_document()`] except
 #' for `includes` and `latex_engine`.

--- a/R/thaipdf.R
+++ b/R/thaipdf.R
@@ -14,7 +14,7 @@
 #'
 #' @param thai_font (Character) Name of the Thai font to use. Default font is "TH Sarabun New". It can be any Thai font that your system have.
 #' @param line_spacing (Numeric) Spacing between each line. Line spacing 1.5 is recommended for Thai language (default).
-#' @param ... Arguments passed to [`pdf_document()`](https://pkgs.rstudio.com/rmarkdown/reference/pdf_document.html). You may supply any arguments of [`pdf_document()`] except
+#' @param ... Arguments to pass to [`pdf_document()`](https://pkgs.rstudio.com/rmarkdown/reference/pdf_document.html). You may supply any valid arguments of [`pdf_document()`] except
 #' for `includes` and `latex_engine`.
 #'
 #'
@@ -30,7 +30,7 @@
 #'  # Simple Conversion
 #'  render("input.Rmd", output_format = thaipdf::thaipdf_document())
 #'
-#'  # Render with Thai font "Laksaman", font size 10pt, and enable Table of Contents
+#'  # Render with Thai font "Laksaman", font size 10pt, enable table of contents
 #'  render("input.Rmd",
 #'         output_format = thaipdf::thaipdf_document(
 #'           thai_font = "Laksaman", # you must have this font in your system
@@ -71,7 +71,7 @@ thaipdf_document <- function(thai_font = "TH Sarabun New",
 #' @description **Thai language** supported conversion of R Markdown to a PDF after resolving the special tokens of **bookdown** (e.g., the tokens for references and labels) to native LaTeX commands.
 #' It is a wrapper around [`bookdown::pdf_book()`](https://pkgs.rstudio.com/bookdown/reference/pdf_book.html) with argument `base_format` set to [thaipdf_document()].
 #'
-#' @param ... Arguments passed to [`pdf_book()`](https://pkgs.rstudio.com/bookdown/reference/pdf_book.html), and then to [thaipdf_document()]. You may supply argument `thai_font` and `line_spacing` in here.
+#' @param ... Arguments to pass to [`bookdown::pdf_book()`](https://pkgs.rstudio.com/bookdown/reference/pdf_book.html), and then to [thaipdf_document()]. You may supply argument `thai_font` and `line_spacing` in here.
 #'
 #' @return An S3 object of class "rmarkdown_output_format" to pass to [`rmarkdown::render()`]
 #' @seealso

--- a/R/use_thai_preamble.R
+++ b/R/use_thai_preamble.R
@@ -31,7 +31,7 @@
 #' @export
 #'
 #' @examples
-#' if (FALSE) {
+#' \dontrun{
 #'  # Running this will write `thai-preamble.tex` to your working directory
 #'  use_thai_preamble()
 #'  # Write `thai-preamble.tex` under pre-tex/ directory (a directory must exist)
@@ -39,6 +39,11 @@
 #'  # Specify Thai font to use
 #'  use_thai_preamble(thai_font = "Laksaman")
 #' }
+#'
+#'  # Example
+#'  .old_wd <- setwd(tempdir())
+#'  use_thai_preamble()
+#'  setwd(.old_wd)
 use_thai_preamble <- function(name = "thai-preamble.tex",
                               thai_font = "TH Sarabun New",
                               line_spacing = 1.5,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,18 @@
+## Resubmission
+
+This is a re-submission. In this version I have:
+
+-   Added \value to .Rd file of `thaipdf_book.Rd` with an explanation of the returned object (object type and class), and the use case of that object.
+
+-   Removed `if(FALSE)` from all examples.
+
+-   Wrapped examples of `thaipdf_book.Rd` and `thaipdf_document.Rd` in `\dontrun{}`. The reasons are the followings: 
+
+    -   A specific Thai font is required to be installed in the system to be able to render example to a PDF.
+    -   It takes a long time to run in each render (about 4.9 - 5.3 sec).
+    -   I also checked the source code of the main function that this package depends on `rmarkdown::pdf_document()` which use `\dontrun{}` in their example as well.
+  
+
 ## R CMD check results
 
 `rhub::check_for_cran()` was used to perform checking.

--- a/dev/cran-fix.Rmd
+++ b/dev/cran-fix.Rmd
@@ -1,0 +1,29 @@
+---
+title: "Fix Resubmit 1"
+author: "kittipos sirivongrungson"
+date: '2022-04-19'
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_knit$set(root.dir = rprojroot::find_rstudio_root_file()) # Set WD to Root
+here::i_am("dev/cran-fix.Rmd")
+library(here)
+
+```
+
+### Questions
+
+What is the return value of `bookdown::pdf_book()`
+
+```{r}
+sloop::otype(rmarkdown::pdf_document())
+class(rmarkdown::pdf_document())
+```
+
+
+```{r}
+sloop::otype(bookdown::pdf_book())
+class(bookdown::pdf_book())
+```
+

--- a/dev/cran-fix.Rmd
+++ b/dev/cran-fix.Rmd
@@ -14,13 +14,37 @@ library(here)
 
 ### Questions
 
-What is the return value of `bookdown::pdf_book()`
+What is the return value of ...
+
+`thaipdf::thaipdf_document()`
+
+```{r}
+sloop::otype(thaipdf::thaipdf_document())
+class(thaipdf::thaipdf_document())
+```
+
+```{r}
+thaipdf::thaipdf_document()$pandoc$args
+```
+
+
+`rmarkdown::pdf_document()`
 
 ```{r}
 sloop::otype(rmarkdown::pdf_document())
 class(rmarkdown::pdf_document())
 ```
 
+
+`thaipdf::thaipdf_book()`
+
+```{r}
+sloop::otype(thaipdf::thaipdf_book())
+class(thaipdf::thaipdf_book())
+```
+
+
+`bookdown::pdf_book()`
 
 ```{r}
 sloop::otype(bookdown::pdf_book())

--- a/dev/cran.Rmd
+++ b/dev/cran.Rmd
@@ -46,6 +46,8 @@ There will always be one NOTE when you first submit your package.
 rhub::platforms()
 ```
 
+Run this
+
 ```{r}
 cran_prep <- rhub::check_for_cran()
 cran_prep$cran_summary()

--- a/man/thaipdf_book.Rd
+++ b/man/thaipdf_book.Rd
@@ -7,7 +7,7 @@
 thaipdf_book(...)
 }
 \arguments{
-\item{...}{Arguments passed to \href{https://pkgs.rstudio.com/bookdown/reference/pdf_book.html}{\code{pdf_book()}}, and then to \code{\link[=thaipdf_document]{thaipdf_document()}}. You may supply argument \code{thai_font} and \code{line_spacing} in here.}
+\item{...}{Arguments to pass to \href{https://pkgs.rstudio.com/bookdown/reference/pdf_book.html}{\code{bookdown::pdf_book()}}, and then to \code{\link[=thaipdf_document]{thaipdf_document()}}. You may supply argument \code{thai_font} and \code{line_spacing} in here.}
 }
 \value{
 An S3 object of class "rmarkdown_output_format" to pass to \code{\link[rmarkdown:render]{rmarkdown::render()}}

--- a/man/thaipdf_book.Rd
+++ b/man/thaipdf_book.Rd
@@ -9,12 +9,15 @@ thaipdf_book(...)
 \arguments{
 \item{...}{Arguments passed to \href{https://pkgs.rstudio.com/bookdown/reference/pdf_book.html}{\code{pdf_book()}}, and then to \code{\link[=thaipdf_document]{thaipdf_document()}}. You may supply argument \code{thai_font} and \code{line_spacing} in here.}
 }
+\value{
+An S3 object of class "rmarkdown_output_format" to pass to \code{\link[rmarkdown:render]{rmarkdown::render()}}
+}
 \description{
 \strong{Thai language} supported conversion of R Markdown to a PDF after resolving the special tokens of \strong{bookdown} (e.g., the tokens for references and labels) to native LaTeX commands.
 It is a wrapper around \href{https://pkgs.rstudio.com/bookdown/reference/pdf_book.html}{\code{bookdown::pdf_book()}} with argument \code{base_format} set to \code{\link[=thaipdf_document]{thaipdf_document()}}.
 }
 \examples{
-if(FALSE){
+\dontrun{
  library(rmarkdown)
 
  # Simple Conversion

--- a/man/thaipdf_document.Rd
+++ b/man/thaipdf_document.Rd
@@ -7,7 +7,7 @@
 thaipdf_document(thai_font = "TH Sarabun New", line_spacing = 1.5, ...)
 }
 \arguments{
-\item{thai_font}{(Character) Name of the Thai font to use. Default font is "TH Sarabun New". It can be any Thai font that your system have.}
+\item{thai_font}{(Character) Name of the Thai font to use. Default font is "TH Sarabun New". It can be any Thai font that installed in your system.}
 
 \item{line_spacing}{(Numeric) Spacing between each line. Line spacing 1.5 is recommended for Thai language (default).}
 

--- a/man/thaipdf_document.Rd
+++ b/man/thaipdf_document.Rd
@@ -15,7 +15,7 @@ thaipdf_document(thai_font = "TH Sarabun New", line_spacing = 1.5, ...)
 for \code{includes} and \code{latex_engine}.}
 }
 \value{
-R Markdown output format passing to \code{\link[rmarkdown:render]{rmarkdown::render()}}
+An S3 object of class "rmarkdown_output_format" to pass to \code{\link[rmarkdown:render]{rmarkdown::render()}}
 }
 \description{
 \strong{Thai language} supported conversion of R Markdown to a PDF or LaTeX document.
@@ -27,8 +27,8 @@ This function injects preamble fragment of Thai \LaTeX typesetting into the prea
 and set \code{latex_engine} to "xelatex".
 }
 \examples{
-if(FALSE){
- library(rmarkdown)
+\dontrun{
+library(rmarkdown)
 
  # Simple Conversion
  render("input.Rmd", output_format = thaipdf::thaipdf_document())

--- a/man/thaipdf_document.Rd
+++ b/man/thaipdf_document.Rd
@@ -11,7 +11,7 @@ thaipdf_document(thai_font = "TH Sarabun New", line_spacing = 1.5, ...)
 
 \item{line_spacing}{(Numeric) Spacing between each line. Line spacing 1.5 is recommended for Thai language (default).}
 
-\item{...}{Arguments passed to \href{https://pkgs.rstudio.com/rmarkdown/reference/pdf_document.html}{\code{pdf_document()}}. You may supply any arguments of \code{\link[=pdf_document]{pdf_document()}} except
+\item{...}{Arguments to pass to \href{https://pkgs.rstudio.com/rmarkdown/reference/pdf_document.html}{\code{pdf_document()}}. You may supply any valid arguments of \code{\link[=pdf_document]{pdf_document()}} except
 for \code{includes} and \code{latex_engine}.}
 }
 \value{
@@ -33,7 +33,7 @@ library(rmarkdown)
  # Simple Conversion
  render("input.Rmd", output_format = thaipdf::thaipdf_document())
 
- # Render with Thai font "Laksaman", font size 10pt, and enable Table of Contents
+ # Render with Thai font "Laksaman", font size 10pt, enable table of contents
  render("input.Rmd",
         output_format = thaipdf::thaipdf_document(
           thai_font = "Laksaman", # you must have this font in your system

--- a/man/use_thai_preamble.Rd
+++ b/man/use_thai_preamble.Rd
@@ -44,7 +44,7 @@ Here is the steps:
 }
 }
 \examples{
-if (FALSE) {
+\dontrun{
  # Running this will write `thai-preamble.tex` to your working directory
  use_thai_preamble()
  # Write `thai-preamble.tex` under pre-tex/ directory (a directory must exist)
@@ -52,4 +52,9 @@ if (FALSE) {
  # Specify Thai font to use
  use_thai_preamble(thai_font = "Laksaman")
 }
+
+ # Example
+ .old_wd <- setwd(tempdir())
+ use_thai_preamble()
+ setwd(.old_wd)
 }

--- a/tests/testthat/test-thaipdf.R
+++ b/tests/testthat/test-thaipdf.R
@@ -1,0 +1,21 @@
+
+
+
+# Test: Thai PDF ----------------------------------------------------------
+
+
+test_that("thaipdf_document() return `rmarkdown_output_format`",{
+
+  expect_s3_class(thaipdf::thaipdf_document(), "rmarkdown_output_format")
+
+})
+
+
+# Test: Thai Book ----------------------------------------------------------
+
+
+test_that("thaipdf_book() return `rmarkdown_output_format`",{
+
+  expect_s3_class(thaipdf::thaipdf_book(), "rmarkdown_output_format")
+
+})

--- a/tests/testthat/test-use_thai_preamble.R
+++ b/tests/testthat/test-use_thai_preamble.R
@@ -3,18 +3,6 @@
 # Test: use_thai_preamble() -----------------------------------------------
 
 
-# test_that("use_thai_preamble() works (test in package root)", {
-#
-#   # create file
-#   path <- suppressMessages(use_thai_preamble())
-#   # Check exist & path
-#   expect_true(fs::file_exists("thai-preamble.tex"))
-#   expect_type(path, "character")
-#   # clean up
-#   unlink("thai-preamble.tex")
-#
-# })
-
 test_that("use_thai_preamble() generate file in working dir (use temp file)", {
   # Set Working Dir to Temp Dir
   .old_wd <- setwd(tempdir())


### PR DESCRIPTION
- Add Return value documentation for `thaipdf_book()`
- Remove `if(FALSE)` from all examples and wrap with `\dontrun{}`.